### PR TITLE
Export progressFunc type

### DIFF
--- a/multibar.go
+++ b/multibar.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sethgrid/curse"
 )
 
-type progressFunc func(progress int)
+type ProgressFunc func(progress int)
 
 type BarContainer struct {
 	Bars []*ProgressBar
@@ -83,7 +83,7 @@ func (b *BarContainer) Listen() {
 	b.Println()
 }
 
-func (b *BarContainer) MakeBar(total int, prepend string) progressFunc {
+func (b *BarContainer) MakeBar(total int, prepend string) ProgressFunc {
 	ch := make(chan int)
 	bar := &ProgressBar{
 		Width:           b.screenWidth - len(prepend) - 20,


### PR DESCRIPTION
I would like to organize a few progress bars like so:

```go
barContainer, _ := multibar.New()
barNames := []string{"foo", "bar", "baz"}

bars := make(map[string]multibar.progressFunc)

for _, n := range barNames {
	bars[n] := barContainer.MakeBar(size, n)
}
```

Evidently this is not possible because `multibar.progressFunc` is private. This commit exports the type.